### PR TITLE
feat: Add daily auto-revalidation using Vercel cron job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev run local revalidate-all revalidate-post revalidate-cron help-revalidate
+.PHONY: setup dev run local revalidate revalidate-post
 
 NOTION_PAGE_ID= :=
 setup:
@@ -33,3 +33,10 @@ help-revalidate:
 	@echo "  make revalidate-all TOKEN_FOR_REVALIDATE=your_token"
 	@echo "  make revalidate-post SLUG=post-slug TOKEN_FOR_REVALIDATE=your_token"
 	@echo "  make revalidate-cron TOKEN_FOR_REVALIDATE=your_token"
+
+# Manual revalidation
+revalidate:
+@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)"
+
+revalidate-post:
+@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)&path=/$(SLUG)"

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,25 @@
-.PHONY: setup dev run local revalidate revalidate-post
+.PHONY: setup dev run local revalidate-all revalidate-post
 
 NOTION_PAGE_ID= :=
 setup:
-	docker build . -t notion-based-log ; \
-	docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash -c "yarn install" ; \
-	echo NOTION_PAGE_ID=$(NOTION_PAGE_ID) > .env.local
+docker build . -t notion-based-log ; \
+docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash -c "yarn install" ; \
+echo NOTION_PAGE_ID=$(NOTION_PAGE_ID) > .env.local
 
 dev:
-	docker run -it --rm -v $(PWD):/app -p 8001:3000 notion-based-log /bin/bash -c "yarn run dev"
+docker run -it --rm -v $(PWD):/app -p 8001:3000 notion-based-log /bin/bash -c "yarn run dev"
 
 run:
-	docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash
+docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash
 
 local:
-	yarn dev
+yarn dev
 
-# Revalidation commands
+# Manual revalidation commands
 revalidate-all:
-	@echo "🔄 Revalidating all pages..."
-	@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)"
-
-revalidate-post:
-	@echo "📝 Revalidating post: $(SLUG)"
-	@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)&path=/$(SLUG)"
-
-revalidate-cron:
-	@echo "⏰ Running cron revalidation..."
-	@curl -s "http://localhost:3000/api/cron/revalidate-all?secret=$(TOKEN_FOR_REVALIDATE)"
-
-help-revalidate:
-	@echo "🔄 Revalidation Commands:"
-	@echo "  make revalidate-all TOKEN_FOR_REVALIDATE=your_token"
-	@echo "  make revalidate-post SLUG=post-slug TOKEN_FOR_REVALIDATE=your_token"
-	@echo "  make revalidate-cron TOKEN_FOR_REVALIDATE=your_token"
-
-# Manual revalidation
-revalidate:
+@echo "🔄 Revalidating all pages..."
 @curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)"
 
 revalidate-post:
+@echo "📝 Revalidating post: $(SLUG)..."
 @curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)&path=/$(SLUG)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup dev run
+.PHONY: setup dev run local revalidate-all revalidate-post revalidate-cron help-revalidate
 
 NOTION_PAGE_ID= :=
 setup:
@@ -14,3 +14,22 @@ run:
 
 local:
 	yarn dev
+
+# Revalidation commands
+revalidate-all:
+	@echo "🔄 Revalidating all pages..."
+	@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)"
+
+revalidate-post:
+	@echo "📝 Revalidating post: $(SLUG)"
+	@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)&path=/$(SLUG)"
+
+revalidate-cron:
+	@echo "⏰ Running cron revalidation..."
+	@curl -s "http://localhost:3000/api/cron/revalidate-all?secret=$(TOKEN_FOR_REVALIDATE)"
+
+help-revalidate:
+	@echo "🔄 Revalidation Commands:"
+	@echo "  make revalidate-all TOKEN_FOR_REVALIDATE=your_token"
+	@echo "  make revalidate-post SLUG=post-slug TOKEN_FOR_REVALIDATE=your_token"
+	@echo "  make revalidate-cron TOKEN_FOR_REVALIDATE=your_token"

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,52 @@
-.PHONY: setup dev run local revalidate-all revalidate-post
+.PHONY: setup dev run local revalidate-all revalidate-post check-env
 
-NOTION_PAGE_ID= :=
-setup:
-docker build . -t notion-based-log ; \
-docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash -c "yarn install" ; \
-echo NOTION_PAGE_ID=$(NOTION_PAGE_ID) > .env.local
+# Load environment variables from .env.local if it exists
+ifneq (,$(wildcard .env.local))
+    include .env.local
+    export
+endif
+
+# Required environment variables with fallback to .env.local values
+NOTION_PAGE_ID ?= $(NOTION_PAGE_ID)
+NEXT_JS_SITE_URL ?= $(NEXT_JS_SITE_URL)
+TOKEN_FOR_REVALIDATE ?= $(TOKEN_FOR_REVALIDATE)
+
+# Environment variable validation
+check-env:
+ifndef NOTION_PAGE_ID
+	$(error NOTION_PAGE_ID is not set. Please set it in .env.local or provide it as an argument)
+endif
+ifndef NEXT_JS_SITE_URL
+	$(error NEXT_JS_SITE_URL is not set. Please set it in .env.local or provide it as an argument)
+endif
+ifndef TOKEN_FOR_REVALIDATE
+	$(error TOKEN_FOR_REVALIDATE is not set. Please set it in .env.local or provide it as an argument)
+endif
+
+setup: check-env
+	docker build . -t notion-based-log ; \
+	docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash -c "yarn install" ; \
+	echo NOTION_PAGE_ID=$(NOTION_PAGE_ID) > .env.local
 
 dev:
-docker run -it --rm -v $(PWD):/app -p 8001:3000 notion-based-log /bin/bash -c "yarn run dev"
+	docker run -it --rm -v $(PWD):/app -p 8001:3000 notion-based-log /bin/bash -c "yarn run dev"
 
 run:
-docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash
+	docker run -it --rm -v $(PWD):/app notion-based-log /bin/bash
 
 local:
-yarn dev
+	yarn dev
 
 # Manual revalidation commands
-revalidate-all:
-@echo "🔄 Revalidating all pages..."
-@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)"
+revalidate-all: check-env
+	@echo "🔄 Revalidating all pages..."
+	@echo "Using NEXT_JS_SITE_URL: $(NEXT_JS_SITE_URL)"
+	@curl -s "$(NEXT_JS_SITE_URL)/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)"
 
-revalidate-post:
-@echo "📝 Revalidating post: $(SLUG)..."
-@curl -s "http://localhost:3000/api/revalidate?secret=$(TOKEN)&path=/$(SLUG)"
+revalidate-post: check-env
+ifndef SLUG
+	$(error SLUG is not set. Please provide it using: make revalidate-post SLUG=your-post-slug)
+endif
+	@echo "📝 Revalidating post: $(SLUG)..."
+	@echo "Using NEXT_JS_SITE_URL: $(NEXT_JS_SITE_URL)"
+	@curl -s "$(NEXT_JS_SITE_URL)/api/revalidate?secret=$(TOKEN_FOR_REVALIDATE)&path=/$(SLUG)"

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,7 @@ ifneq (,$(wildcard .env.local))
     export
 endif
 
-# Required environment variables with fallback to .env.local values
-NOTION_PAGE_ID ?= $(NOTION_PAGE_ID)
-NEXT_JS_SITE_URL ?= $(NEXT_JS_SITE_URL)
-TOKEN_FOR_REVALIDATE ?= $(TOKEN_FOR_REVALIDATE)
+# Required environment variables (will use values from .env.local if not set)
 
 # Environment variable validation
 check-env:

--- a/src/pages/api/cron/revalidate-all.ts
+++ b/src/pages/api/cron/revalidate-all.ts
@@ -1,0 +1,142 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { getPosts } from "../../../apis"
+
+/**
+ * Vercel Cron Job API for automatic site revalidation
+ * Uses existing TOKEN_FOR_REVALIDATE for authentication
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  // Support both query parameter and Authorization header
+  const { secret } = req.query
+  const authHeader = req.headers.authorization
+  const providedSecret = secret || authHeader?.replace('Bearer ', '')
+
+  // Verify using existing TOKEN_FOR_REVALIDATE
+  if (providedSecret !== process.env.TOKEN_FOR_REVALIDATE) {
+    console.error('❌ Unauthorized cron attempt:', { 
+      hasSecret: !!providedSecret,
+      timestamp: new Date().toISOString()
+    })
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  // Only allow POST requests from Vercel cron (but also support GET for manual testing)
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  try {
+    console.log('🕐 Starting scheduled revalidation...', {
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      userAgent: req.headers['user-agent']
+    })
+
+    const startTime = Date.now()
+
+    // Get all posts from Notion
+    const posts = await getPosts()
+    console.log(`📚 Found ${posts.length} posts to revalidate`)
+
+    // Define all pages to revalidate
+    const mainPages = [
+      '/',           // Home page
+      '/categories', // Categories page
+      '/tags',       // Tags page
+      '/feed.xml',   // RSS feed
+      '/sitemap.xml' // Sitemap
+    ]
+
+    const results: {
+      mainPages: Array<{ page: string; success: boolean; error?: string }>
+      posts: Array<{ slug: string; success: boolean; error?: string }>
+      errors: string[]
+    } = {
+      mainPages: [],
+      posts: [],
+      errors: []
+    }
+
+    // Revalidate main pages
+    console.log('🏠 Revalidating main pages...')
+    for (const page of mainPages) {
+      try {
+        await res.revalidate(page)
+        results.mainPages.push({ page, success: true })
+        console.log(`✅ Main page revalidated: ${page}`)
+      } catch (error: any) {
+        const errorMsg = error.message || 'Unknown error'
+        results.mainPages.push({ page, success: false, error: errorMsg })
+        results.errors.push(`Main page ${page}: ${errorMsg}`)
+        console.error(`❌ Failed to revalidate main page ${page}:`, error)
+      }
+    }
+
+    // Revalidate all post pages
+    console.log('📄 Revalidating post pages...')
+    for (const post of posts) {
+      try {
+        await res.revalidate(`/${post.slug}`)
+        results.posts.push({ slug: post.slug, success: true })
+        console.log(`✅ Post revalidated: /${post.slug}`)
+      } catch (error: any) {
+        const errorMsg = error.message || 'Unknown error'
+        results.posts.push({ slug: post.slug, success: false, error: errorMsg })
+        results.errors.push(`Post ${post.slug}: ${errorMsg}`)
+        console.error(`❌ Failed to revalidate post /${post.slug}:`, error)
+      }
+    }
+
+    const endTime = Date.now()
+    const duration = endTime - startTime
+
+    // Calculate success counts
+    const mainPagesSuccess = results.mainPages.filter(r => r.success).length
+    const postsSuccess = results.posts.filter(r => r.success).length
+    const totalSuccess = mainPagesSuccess + postsSuccess
+    const totalAttempted = mainPages.length + posts.length
+
+    const summary = {
+      timestamp: new Date().toISOString(),
+      duration: `${duration}ms`,
+      totalAttempted,
+      totalSuccess,
+      totalErrors: results.errors.length,
+      mainPages: {
+        total: mainPages.length,
+        success: mainPagesSuccess,
+        failed: mainPages.length - mainPagesSuccess
+      },
+      posts: {
+        total: posts.length,
+        success: postsSuccess,
+        failed: posts.length - postsSuccess
+      }
+    }
+
+    console.log('🎉 Revalidation completed:', summary)
+
+    // Return detailed response
+    return res.status(200).json({
+      success: true,
+      message: `Successfully revalidated ${totalSuccess}/${totalAttempted} pages`,
+      ...summary,
+      ...(results.errors.length > 0 && { 
+        errors: results.errors.slice(0, 10) // Limit error list
+      })
+    })
+
+  } catch (error: any) {
+    console.error('💥 Cron job failed catastrophically:', error)
+    
+    return res.status(500).json({
+      success: false,
+      error: 'Revalidation failed',
+      message: error.message,
+      timestamp: new Date().toISOString()
+    })
+  }
+}

--- a/src/pages/api/cron/status.ts
+++ b/src/pages/api/cron/status.ts
@@ -21,6 +21,6 @@ export default async function handler(
     hasNotionConfig: !!process.env.NOTION_PAGE_ID,
     hasRevalidateToken: !!process.env.TOKEN_FOR_REVALIDATE,
     cronJobEndpoint: '/api/cron/revalidate-all',
-    schedule: '0 */6 * * * (every 6 hours)'
+    schedule: '0 2 * * * (daily at 2 AM)'
   })
 }

--- a/src/pages/api/cron/status.ts
+++ b/src/pages/api/cron/status.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from "next"
+
+/**
+ * Simple status check API for cron job health monitoring
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { secret } = req.query
+
+  if (secret !== process.env.TOKEN_FOR_REVALIDATE) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  // Simple status check
+  return res.status(200).json({
+    status: 'healthy',
+    timestamp: new Date().toISOString(),
+    environment: process.env.NODE_ENV,
+    hasNotionConfig: !!process.env.NOTION_PAGE_ID,
+    hasRevalidateToken: !!process.env.TOKEN_FOR_REVALIDATE,
+    cronJobEndpoint: '/api/cron/revalidate-all',
+    schedule: '0 */6 * * * (every 6 hours)'
+  })
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/revalidate-all",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 2 * * *"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/revalidate-all",
+      "schedule": "0 */6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## 🚀 What's Changed

Added Vercel cron job for automated daily revalidation of all pages to ensure content freshness and optimal performance. The cron job runs at 2 AM daily to revalidate the home page, category pages, tags, RSS feed, sitemap, and all blog posts.

## 🎯 Type
- [x] ✨ New Feature

## 🧪 Testing
- [x] Tested locally
- [ ] Works on mobile (not applicable)

## 📝 Notes

### Added Features
- Configured Vercel cron job in `vercel.json` to run daily at 2 AM
- Implemented `/api/cron/revalidate-all` endpoint with:
  - Secure authentication using `TOKEN_FOR_REVALIDATE`
  - Comprehensive revalidation of all site pages
  - Detailed logging and error reporting
  - Support for both automated (POST) and manual (GET) triggers

### Implementation Details
- Uses existing `TOKEN_FOR_REVALIDATE` for security
- Revalidates main pages (/, /categories, /tags, /feed.xml, /sitemap.xml)
- Revalidates all individual post pages
- Provides detailed success/failure statistics
- Includes error handling and logging

### Deployment Notes
- Feature activates automatically when merged to main
- Requires `TOKEN_FOR_REVALIDATE` environment variable
- No breaking changes or database modifications

---
**Ready to merge when:** ✅ CI passes