### PR TITLE
feat(ci): Cloudflare Pages 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+# Deploy to Cloudflare Pages via Deploy Hook
+# This workflow triggers Cloudflare Pages deployment on push to main
+# Workaround for automatic Git integration issues
+
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # Allow manual trigger from GitHub Actions UI
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Cloudflare Pages Deploy
+        run: |
+          response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}")
+          if [ "$response" -eq 200 ]; then
+            echo "Successfully triggered Cloudflare Pages deployment"
+          else
+            echo "Failed to trigger deployment. HTTP status: $response"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- GitHub push 시 Cloudflare Pages 배포가 자동으로 트리거되지 않는 문제 해결
- GitHub Actions를 사용하여 Deploy Hook을 호출하는 방식으로 우회

## Changes
- `.github/workflows/deploy.yml` 추가
  - `main` 브랜치 push 시 자동 트리거
  - `workflow_dispatch`로 수동 트리거 가능
  - HTTP 상태 코드 확인으로 배포 성공 여부 검증

## Setup Required
GitHub Secrets에 다음 값 추가 필요:
- `CLOUDFLARE_DEPLOY_HOOK`: Cloudflare Pages Deploy Hook URL

## Test plan
- [x] GitHub Secrets에 `CLOUDFLARE_DEPLOY_HOOK` 설정
- [ ] PR 머지 후 main 브랜치 push 발생
- [ ] GitHub Actions 탭에서 워크플로우 실행 확인
- [ ] Cloudflare Dashboard에서 새 배포 트리거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)